### PR TITLE
Этап E. NotificationPlanner (скользящее окно)

### DIFF
--- a/Core/Notifications/NotificationDebug.swift
+++ b/Core/Notifications/NotificationDebug.swift
@@ -1,0 +1,17 @@
+//
+//  NotificationDebug.swift
+//  Flarmo
+//
+//  Created by Кирилл Марьясов on 9/9/25.
+//
+
+import UserNotifications
+
+enum NotificationDebug {
+    static func dumpPendingIDs() {
+        UNUserNotificationCenter.current().getPendingNotificationRequests { reqs in
+            let ids = reqs.map(\.identifier).sorted()
+            print("[Pending] \(ids.count) → \(ids.joined(separator: ", "))")
+        }
+    }
+}

--- a/Core/Notifications/NotificationFactory.swift
+++ b/Core/Notifications/NotificationFactory.swift
@@ -1,0 +1,47 @@
+//
+//  NotificationFactory.swift
+//  Flarmo
+//
+//  Created by Кирилл Марьясов on 9/9/25.
+//
+
+import Foundation
+import UserNotifications
+
+struct NotificationFactory {
+    static func makeRequest(schedule: Schedule, fireDate: Date, id: String) -> UNNotificationRequest {
+        let content = UNMutableNotificationContent()
+        content.title = schedule.name
+        // В body выносим тип и время срабатывания
+        content.body = makeBody(for: schedule, fireDate: fireDate)
+        content.sound = .default
+
+        // Важно: использовать календарные компоненты пользователя (часовой пояс/ DST)
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.year, .month, .day, .hour, .minute], from: fireDate)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: false)
+
+        return UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+    }
+
+    private static func makeBody(for schedule: Schedule, fireDate: Date) -> String {
+        // Небольшой, но полезный body — локализованный «во столько-то»
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "ru_RU")
+        df.doesRelativeDateFormatting = true
+        df.dateStyle = .short
+        df.timeStyle = .short
+        let when = df.string(from: fireDate)
+
+        switch schedule.type {
+        case .oneTime:
+            return "Разовый будильник — \(when)"
+        case .weekdays:
+            return "Будни — \(when)"
+        case .shiftPattern:
+            return "Сменный график — \(when)"
+        case .customDates:
+            return "Выбранные даты — \(when)"
+        }
+    }
+}

--- a/Core/Notifications/NotificationPlanner.swift
+++ b/Core/Notifications/NotificationPlanner.swift
@@ -1,0 +1,236 @@
+//
+//  NotificationPlanner.swift
+//  Flarmo
+//
+//  Created by Кирилл Марьясов on 9/9/25.
+//
+
+import Foundation
+import UserNotifications
+
+protocol UserNotificationCentering {
+    func add(_ request: UNNotificationRequest)
+    func getPendingIDs(completion: @escaping (Set<String>) -> Void)
+    func remove(withIDs ids: [String])
+}
+
+extension UNUserNotificationCenter: UserNotificationCentering {
+    func add(_ request: UNNotificationRequest) {
+        add(request, withCompletionHandler: nil)
+    }
+    func getPendingIDs(completion: @escaping (Set<String>) -> Void) {
+        getPendingNotificationRequests { reqs in
+            completion(Set(reqs.map(\.identifier)))
+        }
+    }
+    func remove(withIDs ids: [String]) {
+        removePendingNotificationRequests(withIdentifiers: ids)
+    }
+}
+
+protocol RecurrenceCalculating {
+    /// Возвращает массив ближайших дат по типу расписания в заданном окне
+    func nextOccurrences(for schedule: Schedule, from start: Date, until end: Date, limit: Int?) -> [Date]
+}
+
+protocol NotificationPlanning {
+    /// Полный пересчёт для всех расписаний
+    func planAll(schedules: [Schedule])
+    /// Точечный пересчёт для одного расписания (по месту сохранения/изменения)
+    /// Вариант по-умолчанию: подтягивает provider, чтобы соблюдать глобальный лимит.
+    func plan(for schedule: Schedule)
+}
+
+final class NotificationPlanner: NotificationPlanning {
+    private let calculator: RecurrenceCalculating
+    private let registry: NotificationRegistry
+    private let center: UserNotificationCentering
+    private let nowProvider: () -> Date
+    private let queue = DispatchQueue(label: "notification-planner.queue", qos: .userInitiated)
+
+    /// Опциональный провайдер «всех актуальных расписаний», чтобы в `plan(for:)` можно было удерживать глобальный лимит 60.
+    private let allSchedulesProvider: (() -> [Schedule])?
+
+    // MARK: - Debug helper
+    private let debugEnabled: Bool = true
+    private func log(_ message: @autoclosure () -> String) {
+        guard debugEnabled else { return }
+        print("[Planner] " + message())
+    }
+
+    init(
+        calculator: RecurrenceCalculating,
+        registry: NotificationRegistry,
+        center: UserNotificationCentering = UNUserNotificationCenter.current(),
+        nowProvider: @escaping () -> Date = Date.init,
+        allSchedulesProvider: (() -> [Schedule])? = nil
+    ) {
+        self.calculator = calculator
+        self.registry = registry
+        self.center = center
+        self.nowProvider = nowProvider
+        self.allSchedulesProvider = allSchedulesProvider
+    }
+
+    func planAll(schedules: [Schedule]) {
+        queue.async {
+            self._planAll(schedules: schedules)
+        }
+    }
+
+    func plan(for schedule: Schedule) {
+        // Если есть провайдер — делаем глобальный пересчёт, чтобы гарантировать лимит 60.
+        if let provider = allSchedulesProvider {
+            planAll(schedules: provider())
+            return
+        }
+        // Иначе — делаем точечный пересчёт (может слегка превышать глобальный лимит в редком кейсе).
+        queue.async {
+            self._planOnly(schedule: schedule)
+        }
+    }
+
+    // MARK: - Private
+
+    private func _planAll(schedules: [Schedule]) {
+        let now = nowProvider()
+        let windowEnd = Calendar.current.date(byAdding: .day, value: 30, to: now) ?? now.addingTimeInterval(30*24*3600)
+        let maxTotal = 60
+
+        log("planAll: input schedules=\(schedules.count)")
+
+        center.getPendingIDs { systemIDs in
+            self.log("system pending snapshot=\(systemIDs.count)")
+
+            // Самоисцеление реестра: выкинуть несуществующие
+            self.registry.reloadFromSystemSnapshot(systemIDs)
+
+            // 1) Активные расписания
+            let active = schedules.filter { $0.isActive }
+            self.log("active schedules=\(active.count)")
+
+            // 2) Собрать кандидатов: (schedule, date, id)
+            var candidates: [(Schedule, Date, String)] = []
+            candidates.reserveCapacity(128)
+
+            for s in active {
+                let dates = self.calculator.nextOccurrences(for: s, from: now, until: windowEnd, limit: nil)
+                for d in dates {
+                    let id = self.makeID(scheduleID: s.id.uuidString, fireDate: d)
+                    candidates.append((s, d, id))
+                }
+            }
+
+            self.log("candidates total=\(candidates.count)")
+
+            // 3) Убрать то, что уже стоит (и есть у нас в реестре)
+            let currentKnown = self.registry.ids.intersection(systemIDs)
+            var fresh: [(Schedule, Date, String)] = candidates.filter { !currentKnown.contains($0.2) }
+
+            self.log("already known pending kept=\(candidates.count - fresh.count), fresh to add before cap=\(fresh.count)")
+
+            // 4) Глобальный лимит 60 — обрезаем по ближайшим датам
+            fresh.sort { $0.1 < $1.1 }
+            if fresh.count > maxTotal {
+                fresh = Array(fresh.prefix(maxTotal))
+            }
+
+            self.log("fresh to add after cap(\(maxTotal))=\(fresh.count)")
+
+            // 5) Посчитать новые id по расписаниям (для таргетированной чистки старых)
+            let freshIDsBySchedule = Dictionary(grouping: fresh, by: { $0.0.id }).mapValues { Set($0.map { $0.2 }) }
+
+            // 6) Для каждого расписания снять устаревшие ID (которые числятся в системе + реестре, но не попали в новый набор)
+            var idsToRemoveTotal: Set<String> = []
+            for s in active {
+                let prefix = "flarmo.\(s.id.uuidString)."
+                let existingForSchedule = currentKnown.filter { $0.hasPrefix(prefix) }
+                let keep = freshIDsBySchedule[s.id] ?? []
+                let remove = existingForSchedule.subtracting(keep)
+                idsToRemoveTotal.formUnion(remove)
+            }
+
+            self.log("will remove old ids=\(idsToRemoveTotal.count)")
+
+            if !idsToRemoveTotal.isEmpty {
+                self.center.remove(withIDs: Array(idsToRemoveTotal))
+                self.registry.remove(idsToRemoveTotal)
+                self.log("removed old ids=\(idsToRemoveTotal.count)")
+            }
+
+            // 7) Добавить новые pending
+            var idsAdded: Set<String> = []
+            for (schedule, date, id) in fresh {
+                let req = NotificationFactory.makeRequest(schedule: schedule, fireDate: date, id: id)
+                self.center.add(req)
+                idsAdded.insert(id)
+            }
+
+            self.log("added new ids=\(idsAdded.count)")
+
+            // 8) Обновить реестр
+            if !idsAdded.isEmpty {
+                self.registry.add(idsAdded)
+            }
+        }
+    }
+
+    private func _planOnly(schedule: Schedule) {
+        let now = nowProvider()
+        let windowEnd = Calendar.current.date(byAdding: .day, value: 30, to: now) ?? now.addingTimeInterval(30*24*3600)
+
+        log("planOnly: schedule=\(schedule.id) name=\(schedule.name)")
+
+        center.getPendingIDs { systemIDs in
+            self.log("system pending snapshot=\(systemIDs.count)")
+
+            self.registry.reloadFromSystemSnapshot(systemIDs)
+
+            // Снять все старые ID этого расписания, которых не будет в новом наборе
+            let prefix = "flarmo.\(schedule.id.uuidString)."
+
+            // Новый набор ID
+            let dates = self.calculator.nextOccurrences(for: schedule, from: now, until: windowEnd, limit: nil)
+            let newIDs: Set<String> = Set(dates.map { self.makeID(scheduleID: schedule.id.uuidString, fireDate: $0) })
+
+            self.log("newIDs for schedule=\(newIDs.count)")
+
+            let existingForSchedule = self.registry.ids.intersection(systemIDs).filter { $0.hasPrefix(prefix) }
+            let toRemove = existingForSchedule.subtracting(newIDs)
+
+            self.log("toRemove for schedule=\(toRemove.count)")
+
+            if !toRemove.isEmpty {
+                self.center.remove(withIDs: Array(toRemove))
+                self.registry.remove(toRemove)
+                self.log("removed ids=\(toRemove.count)")
+            }
+
+            // Добавить недостающие
+            let toAdd = newIDs.subtracting(existingForSchedule)
+
+            self.log("toAdd for schedule=\(toAdd.count)")
+
+            if !toAdd.isEmpty {
+                for (date, id) in zip(dates, dates.map { self.makeID(scheduleID: schedule.id.uuidString, fireDate: $0) }) {
+                    if toAdd.contains(id) {
+                        let req = NotificationFactory.makeRequest(schedule: schedule, fireDate: date, id: id)
+                        self.center.add(req)
+                    }
+                }
+                self.registry.add(toAdd)
+                self.log("added ids=\(toAdd.count)")
+            }
+        }
+    }
+
+    private func makeID(scheduleID: String, fireDate: Date) -> String {
+        let df = DateFormatter()
+        df.calendar = Calendar(identifier: .gregorian)
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone.current
+        df.dateFormat = "yyyyMMdd'T'HHmmZ"
+        let stamp = df.string(from: fireDate)
+        return "flarmo.\(scheduleID).\(stamp)"
+    }
+}

--- a/Core/Notifications/NotificationRegistry.swift
+++ b/Core/Notifications/NotificationRegistry.swift
@@ -1,0 +1,81 @@
+//
+//  NotificationRegistry.swift
+//  Flarmo
+//
+//  Created by Кирилл Марьясов on 9/9/25.
+//
+
+import Foundation
+
+protocol NotificationRegistry {
+    /// Зарегистрированные нами идентификаторы pending-уведомлений
+    var ids: Set<String> { get }
+    /// Полная замена всех ID (например, после полного пересчёта)
+    func replaceAll(with ids: Set<String>)
+    /// Добавить множество ID
+    func add(_ ids: Set<String>)
+    /// Удалить множество ID
+    func remove(_ ids: Set<String>)
+    /// Самоисцеление: привести локальное состояние к системному снапшоту
+    func reloadFromSystemSnapshot(_ systemIDs: Set<String>)
+}
+
+final class DefaultsNotificationRegistry: NotificationRegistry {
+    private let defaults: UserDefaults
+    private let key: String
+    private let queue = DispatchQueue(label: "notification-registry.queue", qos: .utility)
+    private var cached: Set<String>
+
+    init(defaults: UserDefaults = .standard, key: String = "notification_registry_ids") {
+        self.defaults = defaults
+        self.key = key
+        if let data = defaults.data(forKey: key),
+           let decoded = try? JSONDecoder().decode([String].self, from: data) {
+            self.cached = Set(decoded)
+        } else {
+            self.cached = []
+        }
+    }
+
+    var ids: Set<String> {
+        queue.sync { cached }
+    }
+
+    func replaceAll(with ids: Set<String>) {
+        queue.sync {
+            cached = ids
+            persistLocked()
+        }
+    }
+
+    func add(_ ids: Set<String>) {
+        guard !ids.isEmpty else { return }
+        queue.sync {
+            cached.formUnion(ids)
+            persistLocked()
+        }
+    }
+
+    func remove(_ ids: Set<String>) {
+        guard !ids.isEmpty else { return }
+        queue.sync {
+            cached.subtract(ids)
+            persistLocked()
+        }
+    }
+
+    func reloadFromSystemSnapshot(_ systemIDs: Set<String>) {
+        queue.sync {
+            // Оставляем только то, что реально есть в системе
+            cached = cached.intersection(systemIDs)
+            persistLocked()
+        }
+    }
+
+    private func persistLocked() {
+        let array = Array(cached)
+        if let data = try? JSONEncoder().encode(array) {
+            defaults.set(data, forKey: key)
+        }
+    }
+}

--- a/Domain/RecurrenceCalculator/RecurrenceCalculator.swift
+++ b/Domain/RecurrenceCalculator/RecurrenceCalculator.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct RecurrenceCalculator {
+public struct RecurrenceCalculator: RecurrenceCalculating {
     public struct Config {
         public let calendar: Calendar
         public init(calendar: Calendar = Calendar.current) {
@@ -55,6 +55,15 @@ public struct RecurrenceCalculator {
         case .customDates(let dates):
             return handleCustom(dates: dates, from: start, limit: limit, until: until)
         }
+    }
+
+    // MARK: - RecurrenceCalculating bridge
+    public func nextOccurrences(for schedule: Schedule,
+                                from start: Date,
+                                until end: Date,
+                                limit: Int?) -> [Date] {
+        let lim = limit ?? Int.max
+        return nextOccurrences(for: schedule, from: start, limit: lim, until: end)
     }
 }
 

--- a/Flarmo.xcodeproj/project.pbxproj
+++ b/Flarmo.xcodeproj/project.pbxproj
@@ -16,6 +16,11 @@
 			path = Domain;
 			sourceTree = "<group>";
 		};
+		4F8DCA492E702DE800829D53 /* Core */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Core;
+			sourceTree = "<group>";
+		};
 		4FDEAC472E6858CB00A3BE21 /* Flarmo */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Flarmo;
@@ -67,6 +72,7 @@
 		4FDEAC3C2E6858CB00A3BE21 = {
 			isa = PBXGroup;
 			children = (
+				4F8DCA492E702DE800829D53 /* Core */,
 				4F8DC98D2E6D938400829D53 /* Domain */,
 				4FDEAC692E685DBD00A3BE21 /* Extensions */,
 				4FDEAC552E68591000A3BE21 /* Models */,
@@ -104,6 +110,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				4F8DC98D2E6D938400829D53 /* Domain */,
+				4F8DCA492E702DE800829D53 /* Core */,
 				4FDEAC472E6858CB00A3BE21 /* Flarmo */,
 				4FDEAC552E68591000A3BE21 /* Models */,
 				4FDEAC562E68592500A3BE21 /* ViewModels */,

--- a/Flarmo/AppLifecycle.swift
+++ b/Flarmo/AppLifecycle.swift
@@ -1,0 +1,48 @@
+//
+//  AppLifecycle.swift
+//  Flarmo
+//
+//  Created by Кирилл Марьясов on 9/9/25.
+//
+
+import SwiftUI
+import Combine
+
+final class AppLifecycle: ObservableObject {
+    private var cancellables = Set<AnyCancellable>()
+    private let planner: NotificationPlanning
+    private let schedulesProvider: () -> [Schedule]
+
+    init(planner: NotificationPlanning, schedulesProvider: @escaping () -> [Schedule]) {
+        self.planner = planner
+        self.schedulesProvider = schedulesProvider
+        setupSignals()
+    }
+
+    func scenePhaseDidBecomeActive() {
+        planner.planAll(schedules: schedulesProvider())
+    }
+
+    private func setupSignals() {
+        // Смена календарных суток
+        NotificationCenter.default.publisher(for: .NSCalendarDayChanged)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.planner.planAll(schedules: self.schedulesProvider())
+            }.store(in: &cancellables)
+
+        // Существенные изменения времени (включая переходы лето/зима)
+        NotificationCenter.default.publisher(for: UIApplication.significantTimeChangeNotification)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.planner.planAll(schedules: self.schedulesProvider())
+            }.store(in: &cancellables)
+
+        // Смена часового пояса
+        NotificationCenter.default.publisher(for: NSNotification.Name.NSSystemTimeZoneDidChange)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.planner.planAll(schedules: self.schedulesProvider())
+            }.store(in: &cancellables)
+    }
+}

--- a/Flarmo/FlarmoApp.swift
+++ b/Flarmo/FlarmoApp.swift
@@ -10,12 +10,23 @@ import UserNotifications
 
 @main
 struct FlarmoApp: App {
+    private let registry = DefaultsNotificationRegistry()
+    private let calculator = RecurrenceCalculator()
+    private let planner: NotificationPlanner
     // private let appRepo: ScheduleRepository = InMemoryScheduleRepository()
-    private let appRepo: ScheduleRepository = FileScheduleRepository()  // ← вот так
+    private let appRepo = FileScheduleRepository()  // ← вот так
     @Environment(\.scenePhase) private var scenePhase
     private let bootstrap: AppBootstrap
+    @State private var lastPlanAllAt: Date = .distantPast
 
     init() {
+        self.planner = NotificationPlanner(
+            calculator: calculator,
+            registry: registry,
+            center: UNUserNotificationCenter.current(),
+            nowProvider: Date.init
+        )
+        UNUserNotificationCenter.current().delegate = NotificationService.shared
         self.bootstrap = AppBootstrap(repo: appRepo)
         NotificationSchedulerV2.registerCategories()
         bootstrap.start()
@@ -23,16 +34,26 @@ struct FlarmoApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ScheduleListView(repo: appRepo)
+            ScheduleListView(repo: appRepo, planner: planner)
                 .onAppear {
                     NotificationService.shared.requestPermission { granted in
                         print("Разрешение на уведомления: \(granted)")
+                        NotificationService.shared.removeLegacyPending {
+                            // Первичный прогон планировщика после очистки легаси
+                            planner.planAll(schedules: appRepo.getAll())
+                            lastPlanAllAt = Date()
+                        }
                     }
                 }
         }
         .onChange(of: scenePhase) { phase in
             if phase == .active {
                 bootstrap.sceneBecameActive()
+                let now = Date()
+                if now.timeIntervalSince(lastPlanAllAt) > 2 {
+                    planner.planAll(schedules: appRepo.getAll())
+                    lastPlanAllAt = now
+                }
             }
         }
     }

--- a/Services/NotificationSchedulerV2.swift
+++ b/Services/NotificationSchedulerV2.swift
@@ -13,78 +13,16 @@ protocol NotificationsScheduling {
 }
 
 final class NotificationSchedulerV2: NotificationsScheduling {
-    private let center = UNUserNotificationCenter.current()
-    private let calc: ScheduleCalculating
-    private var calendar: Calendar = { var cal = Calendar.current; cal.timeZone = .current; return cal }()
-    private static let isoFormatter: ISO8601DateFormatter = { let f = ISO8601DateFormatter(); f.timeZone = .current; f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f }()
-    private let queue = DispatchQueue(label: "notif.scheduler.v2")
-    private var pendingWork: DispatchWorkItem?
-    init(calc: ScheduleCalculating = ScheduleCalculator()) { self.calc = calc }
+    /// Легаси-класс. Оставлен как заглушка, чтобы старые вызовы не ломали поведение.
+    /// Фактическое планирование делается через NotificationPlanner (этап E).
+
+    init() {}
 
     func reschedule(for schedules: [Schedule]) {
-        queue.async {
-            let thread = Thread.isMainThread ? "main" : "bg"
-            print("[NotificationScheduler] reschedule request: count=\(schedules.count) on thread=\(thread)")
-            guard !schedules.isEmpty else { return }
-            self.pendingWork?.cancel()
-            let work = DispatchWorkItem { [weak self] in
-                self?._rescheduleNow(for: schedules)
-            }
-            self.pendingWork = work
-            self.queue.asyncAfter(deadline: .now() + 0.15, execute: work)
-        }
+        // no-op: пересчёт теперь выполняет NotificationPlanner.
+        // Оставлено пустым намеренно, чтобы не плодить дубли «sched_*» и не путать логи.
     }
 
-    private func _rescheduleNow(for schedules: [Schedule]) {
-        print("[NotificationScheduler] Rescheduling for \(schedules.count) schedules")
-        center.getPendingNotificationRequests { [weak self] pending in
-            let ourIds = pending
-                .map(\.identifier)
-                .filter { $0.hasPrefix("sched_") }
-            print("[NotificationScheduler] total pending before purge: \(pending.count)")
-            print("[NotificationScheduler] Removing old v2 notifications: count=\(ourIds.count)")
-
-            self?.center.removePendingNotificationRequests(withIdentifiers: ourIds)
-            self?.scheduleNew(for: schedules)
-        }
-    }
-
-    private func scheduleNew(for schedules: [Schedule]) {
-        let active = schedules.filter { $0.isActive }
-        guard !active.isEmpty else { return }
-        for s in active {
-            let nexts = calc.nextTriggers(for: s, limit: 8, from: Date())
-            guard !nexts.isEmpty else { continue }
-            print("[NotificationScheduler] \(s.name) → scheduling \(nexts.count) triggers")
-            for date in nexts {
-                let triggerDate = date
-                if triggerDate <= Date() { continue }
-                let trigger = UNCalendarNotificationTrigger(
-                    dateMatching: calendar.dateComponents(
-                        [.year, .month, .day, .hour, .minute, .second], from: triggerDate),
-                    repeats: false
-                )
-                let content = UNMutableNotificationContent()
-                content.title = s.name
-                content.body = "Будильник"
-                content.sound = s.toneId != nil
-                    ? UNNotificationSound(named: UNNotificationSoundName(rawValue: "\(s.toneId!).caf"))
-                    : .default
-                content.categoryIdentifier = "ALARM_CATEGORY"
-
-                let id = "sched_\(s.id.uuidString)_\(Int(triggerDate.timeIntervalSince1970))"
-                let req = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
-                center.add(req) { error in
-                    if let error = error {
-                        print("[NotificationScheduler] ❌ add id=\(id) ts=\(Self.isoFormatter.string(from: triggerDate)) error=\(error)")
-                    } else {
-                        print("[NotificationScheduler] ✅ scheduled id=\(id) ts=\(Self.isoFormatter.string(from: triggerDate)) name=\(s.name)")
-                    }
-                }
-            }
-        }
-    }
-    
     static func registerCategories() {
         let snooze = UNNotificationAction(identifier: "SNOOZE_ACTION", title: "Отложить", options: [])
         let stop = UNNotificationAction(identifier: "STOP_ACTION", title: "Выключить", options: [.destructive])

--- a/Services/NotificationService.swift
+++ b/Services/NotificationService.swift
@@ -38,42 +38,39 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate, Notificat
     
     // MARK: - Scheduling
     
+    @available(*, deprecated, message: "Deprecated. Use NotificationPlanner with Schedule instead.")
     func scheduleNotification(for alarm: Alarm) {
-        guard alarm.isActive else {
-            print("⏸ Будильник \(alarm.id) выключен, уведомление не ставим")
-            return
-        }
-        
-        let content = UNMutableNotificationContent()
-        content.title = "Будильник"
-        content.body = alarm.label.isEmpty ? "Пора вставать!" : alarm.label
-        content.sound = .default
-        
-        let triggerDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: alarm.time)
-        let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: false)
-        
-        let request = UNNotificationRequest(identifier: alarm.id.uuidString, content: content, trigger: trigger)
-        
-        center.add(request) { error in
-            if let error = error {
-                print("❌ Ошибка планирования уведомления: \(error)")
-            } else {
-                print("✅ Уведомление запланировано на \(alarm.time.formattedDateTime())")
-            }
-        }
+        // DEPRECATED: постановка уведомлений теперь делается через NotificationPlanner (этап E).
+        // Метод оставлен как no-op для сохранения бинарной совместимости.
+        print("[NotificationService] scheduleNotification(for:) is deprecated — ignored. Use NotificationPlanner.")
     }
     
+    @available(*, deprecated, message: "Deprecated. Use NotificationPlanner with Schedule instead.")
     func cancelNotification(for alarm: Alarm) {
-        center.removePendingNotificationRequests(withIdentifiers: [alarm.id.uuidString])
-        print("🗑 Уведомление отменено для \(alarm.id)")
+        // DEPRECATED: отмена уведомлений выполняется через перепланирование NotificationPlanner.
+        print("[NotificationService] cancelNotification(for:) is deprecated — ignored. Use NotificationPlanner.")
     }
     
+    @available(*, deprecated, message: "Deprecated. Use NotificationPlanner with Schedule instead.")
     func updateNotification(for alarm: Alarm) {
-        cancelNotification(for: alarm)
-        scheduleNotification(for: alarm)
+        // DEPRECATED: обновление выполняется через перепланирование NotificationPlanner.
+        print("[NotificationService] updateNotification(for:) is deprecated — ignored. Use NotificationPlanner.")
     }
     
     // MARK: - Debug / Test
+    /// Удаляет старые pending-уведомления формата `sched_...` (до этапа E)
+    func removeLegacyPending(completion: (() -> Void)? = nil) {
+        center.getPendingNotificationRequests { [weak self] reqs in
+            let legacy = reqs.map(\.identifier).filter { $0.hasPrefix("sched_") }
+            if !legacy.isEmpty {
+                self?.center.removePendingNotificationRequests(withIdentifiers: legacy)
+                print("[NotificationService] Removed legacy pending: \(legacy.count)")
+            } else {
+                print("[NotificationService] No legacy pending found")
+            }
+            completion?()
+        }
+    }
     
     func listScheduledNotifications() {
         center.getPendingNotificationRequests { requests in
@@ -109,7 +106,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate, Notificat
                                 willPresent notification: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         print("🔔 Будильник сработал: \(notification.request.content.body)")
-        completionHandler([.banner, .sound])
+        completionHandler([.banner, .sound, .list])
     }
     
     // Срабатывает, когда пользователь открыл уведомление

--- a/Views/ScheduleList/ScheduleListView.swift
+++ b/Views/ScheduleList/ScheduleListView.swift
@@ -9,11 +9,13 @@ import SwiftUI
 
 struct ScheduleListView: View {
     private let repo: ScheduleRepository
+    private let planner: NotificationPlanning
     @StateObject private var vm: ScheduleListViewModel
     @State private var path: [Route] = []
 
-    init(repo: ScheduleRepository) {
+    init(repo: ScheduleRepository, planner: NotificationPlanning) {
         self.repo = repo
+        self.planner = planner
         _vm = StateObject(wrappedValue: ScheduleListViewModel(repo: repo))
     }
 
@@ -28,6 +30,7 @@ struct ScheduleListView: View {
                         Button(role: .destructive) {
                             if let idx = vm.items.firstIndex(where: { $0.id == schedule.id }) {
                                 vm.delete(at: IndexSet(integer: idx))
+                                planner.planAll(schedules: repo.getAll())
                             }
                         } label: {
                             Label("Удалить", systemImage: "trash")
@@ -71,6 +74,7 @@ struct ScheduleListView: View {
                 case .createOneTime:
                     EditOneTimeScheduleView(repo: repo, source: .create) {
                         vm.reload()
+                        planner.planAll(schedules: repo.getAll())
                     }
                 case .createShiftPattern:
                     Text("Сменный график — скоро")
@@ -80,6 +84,7 @@ struct ScheduleListView: View {
                     if case .oneTime = schedule.type {
                         EditOneTimeScheduleView(repo: repo, source: .edit(schedule)) {
                             vm.reload()
+                            planner.planAll(schedules: repo.getAll())
                         }
                     } else {
                         // Пока редактируем только .oneTime. Остальные — чтение.


### PR DESCRIPTION
Что сделано
	• A–E: модель Schedule, генератор дат, фабрика уведомлений, реестр, планировщик (окно 30 дней, ≤60), хуки жизненного цикла.

Ключевые точки
• Планировщик: Flarmo/Core/Notifications/NotificationPlanner.swift
• Фабрика: Flarmo/Core/Notifications/NotificationFactory.swift
• Реестр: Flarmo/Core/Notifications/NotificationRegistry.swift
• Инициализация: Flarmo/FlarmoApp.swift
• Точки вызова: Flarmo/ScheduleListView.swift (create/edit/delete)

Выпил легаси
• NotificationSchedulerV2 → заглушка (no-op), оставлена registerCategories().
• NotificationService.schedule/cancel/update(Alarm) → deprecated + no-op.

Триггеры пересчёта
• Старт (после разрешения) + foreground (с дебаунсом 2s) + системные события времени/часового пояса.

Логи и проверка
• Включены подробные логи [Planner] ...
• Разовая очистка sched_* при старте.

Что проверить ревьюеру
• Нет прямых UNUserNotificationCenter.current().add вне Planner/Service.
• Нет оставшихся ссылок на NotificationScheduler / sched_ / Alarm.
• Потокобезопасность: DefaultsNotificationRegistry — доступ только через очередь.
• Формат ID: flarmo.<UUID>.yyyyMMddTHHmmZ, детерминизм, без дублей.
• Таймзона/календари: в фабрике и калькуляторе использован .current, DST корректный.

Известные ограничения
• pending-окно жёстко 30д (можно вынести в конфиг).
• нет юнит-тестов на Planner/Calculator (опционально добавим).